### PR TITLE
ensured left padding of friend list in socially engaged

### DIFF
--- a/gimmick/static/css/engage.css
+++ b/gimmick/static/css/engage.css
@@ -355,6 +355,9 @@ span.switch.on {
     margin-right: 5px;
 }
 
+#friend-list {
+    padding-left: 20px;
+}
 #friend-list li {
     margin: 0 0 0.3em;
 }

--- a/gimmick/static/css/engage.css
+++ b/gimmick/static/css/engage.css
@@ -133,10 +133,6 @@ a {
     text-align: right;
 }
 
-.simple-list {
-    padding-left: inherit;
-}
-
 dl.callout {
     margin-top: 0;
     margin-bottom: 15px;

--- a/gimmick/templates/gimmick/engage.html
+++ b/gimmick/templates/gimmick/engage.html
@@ -105,7 +105,7 @@
                         </div>
                         <div class="panel-body top-friends">
                             <span class="switch on">
-                                <ol id=friend-list class=simple-list></ol>
+                                <ol id=friend-list></ol>
                             </span>
                             <span class=switch>
                                 <p>You're the first of your friends to be ranked!</p>


### PR DESCRIPTION
(With the JavaScript to hide rank when it's just you temporarily disabled):

**Before**

![before](https://www.dropbox.com/s/mf211zeq6hfqr89/Screenshot%202015-04-13%2013.25.34.png?dl=1)

**After**

![after](https://www.dropbox.com/s/uhmjnn3jgfo8xeo/Screenshot%202015-04-13%2013.24.32.png?dl=1)

The list was set to inherit padding from its container, but then we inserted a `<span>` around the list. This enforces the appropriate left padding.
